### PR TITLE
add MSYS2 MinGW64 CI build for Windows

### DIFF
--- a/.github/workflows/windows-msys2.yml
+++ b/.github/workflows/windows-msys2.yml
@@ -1,0 +1,40 @@
+name: Windows MSYS2 Build
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          update: true
+          pacboy: >-
+            toolchain:p ninja:p cmake:p
+            qt5:p opencv:p sqlite3:p
+      - name: Build deduper
+        run: |
+          mkdir build && cd build
+          cmake .. -G Ninja
+          cmake --build . -j
+          cd ..
+      - name: Prepare for package
+        continue-on-error: true
+        run: |
+          mkdir package_workspace && cd package_workspace
+          cp ../build/qdeduper/qdeduper.exe ./
+          strip -S ./qdeduper.exe
+          windeployqt -winextras --no-quick-import --no-translations --no-opengl-sw --no-angle --no-system-d3d-compiler ./qdeduper.exe
+          ldd ./qdeduper.exe > deps-qdeduper.txt
+          bash -c 'while read -r line; do path=$(cut -d" " -f3 <<<$line); cp -v $path ./; done <<<$(grep ".*mingw.*bin" deps-qdeduper.txt); exit 0'
+          rm deps-qdeduper.txt
+          # done
+          cd ../
+      - uses: actions/upload-artifact@v2
+        with:
+          name: msys2-mingw-w64-x86_64-windows
+          path: package_workspace/*


### PR DESCRIPTION
This PR will add a MSYS2 MinGW based Windows build to help test if Windows support is broken, and will also generate a downloadable artifact to use/test it locally.